### PR TITLE
Replaced deprecated oxid functions which were removed in OXID 4.9 / 5.2

### DIFF
--- a/controllers/admin/marm_piwik_setup.php
+++ b/controllers/admin/marm_piwik_setup.php
@@ -71,7 +71,8 @@ class marm_piwik_setup extends oxAdminDetails
      */
     public function save()
     {
-        $aParams = oxConfig::getParameter( "editval" );
+        $oConfig = oxRegistry::getConfig();
+        $aParams = $oConfig->getRequestParameter( "editval" );
         $oMarmPiwik = $this->getMarmPiwik();
         $oMarmPiwik->changeConfig($aParams);
     }

--- a/core/marm_piwik.php
+++ b/core/marm_piwik.php
@@ -96,7 +96,7 @@ class marm_piwik {
 
     protected function _loadConfig()
     {
-        $aSavedConfig = oxConfig::getInstance()->getShopConfVar(self::CONFIG_ENTRY_NAME);
+        $aSavedConfig = oxRegistry::getConfig()->getShopConfVar(self::CONFIG_ENTRY_NAME);
         if ($aSavedConfig && count($aSavedConfig) == count($this->_aConfig)) {
             $this->_aConfig = $aSavedConfig;
         }
@@ -108,7 +108,7 @@ class marm_piwik {
 
     protected function _saveConfig()
     {
-        oxConfig::getInstance()->saveShopConfVar( 'arr', self::CONFIG_ENTRY_NAME, $this->_aConfig );
+        oxRegistry::getConfig()->saveShopConfVar( 'arr', self::CONFIG_ENTRY_NAME, $this->_aConfig );
     }
 
     public function getConfig()
@@ -190,7 +190,7 @@ class marm_piwik {
      */
     protected function _getViewOrder()
     {
-        return oxConfig::getInstance()->getActiveView();
+        return oxRegistry::getConfig()->getActiveView();
     }
 
     /**
@@ -254,12 +254,12 @@ class marm_piwik {
     public function setPiwikParamsForSearch($oViewObject)
     {
         $cntResults = $oViewObject->isEmptySearch() ? 0 : $oViewObject->getArticleCount();
-	$this->addPushParams(
-	    'trackSiteSearch',
-	    $oViewObject->getSearchParam(),
-	    false,
-	    $cntResults
-	);
+        $this->addPushParams(
+            'trackSiteSearch',
+            $oViewObject->getSearchParam(),
+            false,
+            $cntResults
+        );
     }
 
     /**


### PR DESCRIPTION
oxConfig::getInstance() to oxRegistry::getConfig()
getParameter() to getRequestParameter()