### PR TITLE
Replaced deprecated and removed function oxSession::getInstance()

### DIFF
--- a/core/marm_piwik.php
+++ b/core/marm_piwik.php
@@ -327,7 +327,7 @@ class marm_piwik {
          * may NOT have getBasket method (for example Details)
          * @var oxBasket $oBasket
          */
-        $oBasket = oxSession::getInstance()->getBasket();
+        $oBasket = oxRegistry::getSession()->getBasket();
         $this->_setEcommerceItemsByBasket($oBasket);
         $this->addPushParams('trackEcommerceCartUpdate', $oBasket->getPrice()->getBruttoPrice());
     }


### PR DESCRIPTION
Replaced deprecated and removed function oxSession::getInstance() with oxRegistry::getSession()
because oxSession::getInstance() has been removed in CE 4.9 and EE 5.2