### PR TITLE
decode search param for search tracking

### DIFF
--- a/core/marm_piwik.php
+++ b/core/marm_piwik.php
@@ -256,7 +256,7 @@ class marm_piwik {
         $cntResults = $oViewObject->isEmptySearch() ? 0 : $oViewObject->getArticleCount();
 	$this->addPushParams(
 	    'trackSiteSearch',
-	    $oViewObject->getSearchParam(),
+	    urldecode($oViewObject->getSearchParam()),
 	    false,
 	    $cntResults
 	);


### PR DESCRIPTION
fixes issue with keyword tracking where the search phrase was not url decoded